### PR TITLE
update GNOME runtime to 46

### DIFF
--- a/io.github.cboxdoerfer.FSearch.yml
+++ b/io.github.cboxdoerfer.FSearch.yml
@@ -1,6 +1,6 @@
 app-id: io.github.cboxdoerfer.FSearch
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: fsearch
 finish-args:


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024.