### PR TITLE
update GNOME runtime to 48

### DIFF
--- a/io.github.cboxdoerfer.FSearch.yml
+++ b/io.github.cboxdoerfer.FSearch.yml
@@ -1,6 +1,6 @@
 app-id: io.github.cboxdoerfer.FSearch
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: fsearch
 finish-args:


### PR DESCRIPTION
The GNOME 46 runtime is no longer supported as of April 17, 2025 -> update to GNOME 48 runtime.